### PR TITLE
Don't catch errors in a policy class's constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-authorization",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Authorization through JavaScript classes with support for React",
   "homepage": "https://github.com/simplymadeapps/simple-authorization",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -137,13 +137,13 @@ function getPolicyData(classOrRecord, recordAttributes) {
  */
 function policy(classOrRecord, recordAttributes) {
   var policyData = getPolicyData(classOrRecord, recordAttributes);
+  var PolicyClass = SimpleAuthorization.policyResolver(policyData.modelName);
 
-  try {
-    var PolicyClass = SimpleAuthorization.policyResolver(policyData.modelName);
+  if (typeof PolicyClass === "function") {
     return new PolicyClass(policyData);
-  } catch (error) {
-    throw new Error("SimpleAuthorization.policyResolver could not resolve a policy class for " + policyData.modelName);
   }
+
+  throw new Error("SimpleAuthorization.policyResolver could not resolve a policy class for " + policyData.modelName);
 }
 
 SimpleAuthorization.Authorize = Authorize;


### PR DESCRIPTION
We were catching any error raised when initializing the return value of the policy resolver and throwing our own error saying that a matching policy couldn't be resolved. This might not have been true because there may have been a matching policy class that threw its own error when initialized.

This made it confusing to debug errors occurring in the policy's constructor, so now errors in the constructor will not be caught and will bubble up with the original error message.

Fixes #11.